### PR TITLE
AGL-FR Username

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,7 +2,7 @@ class FavoritesController < ApplicationController
   before_action :require_user
 
   def index
-    @user = User.find(params[:user_id])
+    @user = User.find_by(username: params[:username])
     recipe_ids = Favorite.get_recipe_ids(@user)
     @recipes = Recipe.search_by_ids(recipe_ids)
   end

--- a/app/controllers/friends_controller.rb
+++ b/app/controllers/friends_controller.rb
@@ -2,6 +2,6 @@ class FriendsController < ApplicationController
   before_action :require_user
 
   def index
-    @user = User.find(params[:user_id])
+    @user = User.find_by(username: params[:username])
   end
 end

--- a/app/controllers/profile/friends_controller.rb
+++ b/app/controllers/profile/friends_controller.rb
@@ -6,7 +6,7 @@ class Profile::FriendsController < ApplicationController
   end
 
   def create
-    if current_user.add_friend(params[:email_address])
+    if current_user.add_friend(params[:username])
       current_user.reload
       flash['alert alert-success'] = 'Friend Added Successfully'
     else

--- a/app/controllers/profile/users_controller.rb
+++ b/app/controllers/profile/users_controller.rb
@@ -11,7 +11,7 @@ class Profile::UsersController < ApplicationController
   end
 
   def update
-    current_user.update(bio_params)
+    current_user.update(profile_params)
     current_user.restrictions.delete_all
     diet_params.each do |restriction|
       current_user.restrictions.create(name: restriction.gsub('_', ' '))
@@ -26,7 +26,7 @@ class Profile::UsersController < ApplicationController
     params.permit(:vegetarian, :gluten_free, :vegan, :dairy_free, :ketogenic)
   end
 
-  def bio_params
-    params.permit(:bio)
+  def profile_params
+    params.permit(:bio, :username)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,6 @@ class UsersController < ApplicationController
   before_action :require_user
 
   def show
-    @user = User.find(params[:id])
+    @user = User.find_by(username: params[:username])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   validates :email, presence: true
+  validates :username, uniqueness: true
+  validates :image, presence: true
 
   def add_friend(email_address)
     new_friend = User.find_by(email: email_address)
@@ -30,6 +32,8 @@ class User < ApplicationRecord
   def self.from_omniauth(response)
     find_or_initialize_by(email: response['info']['email']) do |user|
       user.name = response['info']['name']
+      user.username = response['info']['email'].split('@').first if user.username.nil?
+      user.image = response['info']['image']
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,8 +10,8 @@ class User < ApplicationRecord
   validates :username, uniqueness: true
   validates :image, presence: true
 
-  def add_friend(email_address)
-    new_friend = User.find_by(email: email_address)
+  def add_friend(username)
+    new_friend = User.find_by(username: username)
     return false if new_friend.nil? || load_friends.include?(new_friend)
 
     Friendship.create!(user_id: id, friend_id: new_friend.id)

--- a/app/views/friends/index.html.erb
+++ b/app/views/friends/index.html.erb
@@ -4,7 +4,7 @@
   <p><%= @user.name %> has no friends</p>
 <% else %>
   <% @user.friends.each do |friend| %>
-    <%= link_to friend.email, user_path(friend) %>
+    <%= link_to friend.email, user_path(friend.username) %>
   <% end %>
 <% end %>
 

--- a/app/views/friends/index.html.erb
+++ b/app/views/friends/index.html.erb
@@ -4,7 +4,7 @@
   <p><%= @user.name %> has no friends</p>
 <% else %>
   <% @user.friends.each do |friend| %>
-    <%= link_to friend.email, user_path(friend.username) %>
+    <%= link_to friend.username, user_path(friend.username) %>
   <% end %>
 <% end %>
 

--- a/app/views/profile/friends/index.html.erb
+++ b/app/views/profile/friends/index.html.erb
@@ -1,8 +1,8 @@
 <h2>My Friends</h2>
 
 <%= form_tag profile_friends_path do %>
-  <%= label_tag :email_address %>
-  <%= text_field_tag :email_address %>
+  <%= label_tag :username %>
+  <%= text_field_tag :username %>
   <%= submit_tag "Add Friend" %>
 <% end %>
 
@@ -10,7 +10,7 @@
   <p>You have no friends, try adding some :^)</p>
 <% else %>
   <% @friends.each do |friend| %>
-    <%= link_to friend.email, user_path(friend.username) %>
+    <%= link_to friend.username, user_path(friend.username) %>
   <% end %>
 <% end %>
 

--- a/app/views/profile/friends/index.html.erb
+++ b/app/views/profile/friends/index.html.erb
@@ -10,7 +10,7 @@
   <p>You have no friends, try adding some :^)</p>
 <% else %>
   <% @friends.each do |friend| %>
-    <%= link_to friend.email, user_path(friend) %>
+    <%= link_to friend.email, user_path(friend.username) %>
   <% end %>
 <% end %>
 

--- a/app/views/profile/users/edit.html.erb
+++ b/app/views/profile/users/edit.html.erb
@@ -8,6 +8,8 @@
     </div>
     <div class="col-sm-4">
       <%= form_tag profile_path, method: :patch, :class => 'form-group' do %>
+      <h3><%= label_tag "Username" %></h3><br>
+      <%= text_area_tag :username, @user.username, :class => "form-control", :rows => 1 %>
       <h3><%= label_tag "About Me" %></h3><br>
       <%= text_area_tag :bio, @user.bio, :class => "form-control", :rows => 5 %>
       <h3>Default Diet Preferences</h3>

--- a/app/views/profile/users/show.html.erb
+++ b/app/views/profile/users/show.html.erb
@@ -6,10 +6,12 @@
 
 <div class="container" style="margin-top:30px">
   <div class="row">
-    <div class="col-sm-6">
+    <div class="col-sm-4">
       <div class="info-<%= @user.id %>">
-        <h3><%= @user.name %></h3>
-        <b><%= @user.email %></b><br>
+        <h3>Name: <%= @user.name %></h3>
+        <b>Email: <%= @user.email %></b><br>
+        <b>Username: <%= @user.username %></b><br>
+
         <% if @user.bio %>
           <b>About me:</b><br>
           <p><%= @user.bio %></p>
@@ -18,7 +20,10 @@
         <% end %>
       </div>
     </div>
-    <div class="col-sm-6">
+    <div class="col-sm-4">
+      <%= image_tag @user.image %>
+    </div>
+    <div class="col-sm-4">
       <h2>Dietary Restrictions</h2>
       <% if current_user.restrictions.length.zero? %>
         <p>You have no dietary restrictions selected</p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,9 @@
 <h2><%= @user.name %></h2>
 
-<%= link_to "#{@user.name}'s Favorites", user_favorites_path(@user) %> |
-<%= link_to "#{@user.name}'s Friends", user_friends_path(@user) %><br>
+<%= link_to "#{@user.name}'s Favorites", user_favorites_path(@user.username) %> |
+<%= link_to "#{@user.name}'s Friends", user_friends_path(@user.username) %><br>
 <p>Name: <%= @user.name %></p><br>
 <p>Email: <%= @user.email %></p><br>
+<p>Username: <%= @user.username %></p><br>
 <p>Bio: <%= @user.bio %></p>
+<%= image_tag @user.image %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<h2><%= @user.name %></h2>
+<h2><%= @user.username %></h2>
 
 <%= link_to "#{@user.username}'s Favorites", user_favorites_path(@user.username) %> |
 <%= link_to "#{@user.username}'s Friends", user_friends_path(@user.username) %><br>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,9 +1,8 @@
 <h2><%= @user.name %></h2>
 
-<%= link_to "#{@user.name}'s Favorites", user_favorites_path(@user.username) %> |
-<%= link_to "#{@user.name}'s Friends", user_friends_path(@user.username) %><br>
+<%= link_to "#{@user.username}'s Favorites", user_favorites_path(@user.username) %> |
+<%= link_to "#{@user.username}'s Friends", user_friends_path(@user.username) %><br>
 <p>Name: <%= @user.name %></p><br>
-<p>Email: <%= @user.email %></p><br>
 <p>Username: <%= @user.username %></p><br>
 <p>Bio: <%= @user.bio %></p>
 <%= image_tag @user.image %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,11 +16,6 @@ Rails.application.routes.draw do
     resources :friends, only: [:index, :create, :destroy]
   end
 
-  # resources :users, only: [:show] do
-  #   resources :favorites, only: [:index]
-  #   resources :friends, only: [:index]
-  # end
-
   get '/:username', to: 'users#show', as: :user
   get '/:username/favorites', to: 'favorites#index', as: :user_favorites
   get '/:username/friends', to: 'friends#index', as: :user_friends

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,8 +16,12 @@ Rails.application.routes.draw do
     resources :friends, only: [:index, :create, :destroy]
   end
 
-  resources :users, only: [:show] do
-    resources :favorites, only: [:index]
-    resources :friends, only: [:index]
-  end
+  # resources :users, only: [:show] do
+  #   resources :favorites, only: [:index]
+  #   resources :friends, only: [:index]
+  # end
+
+  get '/:username', to: 'users#show', as: :user
+  get '/:username/favorites', to: 'favorites#index', as: :user_favorites
+  get '/:username/friends', to: 'friends#index', as: :user_friends
 end

--- a/db/migrate/20200601220654_add_username_to_users.rb
+++ b/db/migrate/20200601220654_add_username_to_users.rb
@@ -1,0 +1,5 @@
+class AddUsernameToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :username, :string, unique: true
+  end
+end

--- a/db/migrate/20200601222848_add_image_to_users.rb
+++ b/db/migrate/20200601222848_add_image_to_users.rb
@@ -1,0 +1,5 @@
+class AddImageToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :image, :string, default: 'https://i.kym-cdn.com/photos/images/newsfeed/001/076/734/879.jpg'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200530044108) do
+ActiveRecord::Schema.define(version: 20200601222848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,8 @@ ActiveRecord::Schema.define(version: 20200530044108) do
     t.string "bio"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username"
+    t.string "image", default: "https://i.kym-cdn.com/photos/images/newsfeed/001/076/734/879.jpg"
   end
 
   add_foreign_key "favorites", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,2 @@
-User.create(name: 'Ripley Latham', email: 'ripley@puppy.com', bio: 'big dogg :)')
+User.destroy_all
+User.create(name: 'Ripley Latham', email: 'ripley@puppy.com', bio: 'big dogg :)', username: 'bigpup')

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     name { Faker::Creature::Dog.name }
     email  { Faker::Internet.email }
     bio  { Faker::Movies::Ghostbusters.quote }
+    username  { Faker::DrivingLicence.uk_driving_licence }
   end
 end

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe User do
 
       user2.reload
 
-      visit user_favorites_path(user2)
+      visit user_favorites_path(user2.username)
 
       within('#recipe-4584') do
         expect(page).to have_link('Blackened Salmon With Hash Browns and Green Onions', href: recipe_path(4584))

--- a/spec/features/friends/user_can_add_friends_spec.rb
+++ b/spec/features/friends/user_can_add_friends_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe "As a user" do
   it "I can add a new friend from /profile/friends" do
-    user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy")
-    user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy")
+    user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy", username: '321')
+    user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy", username: '123')
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
 
@@ -26,8 +26,8 @@ describe "As a user" do
   end
 
   it "I cannot add a friend using an invalid email" do
-    user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy")
-    user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy")
+    user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy", username: '321')
+    user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy", username: '123')
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
 
@@ -40,8 +40,8 @@ describe "As a user" do
   end
 
   it "I cannot add a friend that is already on my friends list" do
-    user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy")
-    user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy")
+    user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy", username: '321')
+    user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy", username: '123')
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
 

--- a/spec/features/friends/user_can_add_friends_spec.rb
+++ b/spec/features/friends/user_can_add_friends_spec.rb
@@ -16,12 +16,12 @@ describe "As a user" do
     expect(current_path).to eq(profile_friends_path)
     expect(page).to have_content("You have no friends, try adding some :^)")
 
-    fill_in :email_address, with: user_2.email
+    fill_in :username, with: user_2.username
     click_button "Add Friend"
 
     expect(current_path).to eq(profile_friends_path)
     expect(page).to have_content("Friend Added Successfully")
-    expect(page).to have_link(user_2.email, href: user_path(user_2.username))
+    expect(page).to have_link(user_2.username, href: user_path(user_2.username))
     expect(page).to_not have_content("You have no friends, try adding some :^)")
   end
 
@@ -32,7 +32,7 @@ describe "As a user" do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
 
     visit profile_friends_path
-    fill_in :email_address, with: "asfasdf"
+    fill_in :username, with: "asfasdf"
     click_button "Add Friend"
 
     expect(page).to_not have_content("Friend Added Successfully")
@@ -47,13 +47,13 @@ describe "As a user" do
 
     visit profile_friends_path
 
-    fill_in :email_address, with: user_2.email
+    fill_in :username, with: user_2.username
     click_button "Add Friend"
 
     expect(current_path).to eq(profile_friends_path)
     expect(page).to have_content("Friend Added Successfully")
 
-    fill_in :email_address, with: user_2.email
+    fill_in :username, with: user_2.username
     click_button "Add Friend"
     expect(page).to have_content("Invalid Email Entered, Try Again")
   end

--- a/spec/features/friends/user_can_add_friends_spec.rb
+++ b/spec/features/friends/user_can_add_friends_spec.rb
@@ -21,7 +21,7 @@ describe "As a user" do
 
     expect(current_path).to eq(profile_friends_path)
     expect(page).to have_content("Friend Added Successfully")
-    expect(page).to have_link(user_2.email, href: user_path(user_2))
+    expect(page).to have_link(user_2.email, href: user_path(user_2.username))
     expect(page).to_not have_content("You have no friends, try adding some :^)")
   end
 

--- a/spec/features/friends/user_can_visit_friends_profile_from_friends_list_spec.rb
+++ b/spec/features/friends/user_can_visit_friends_profile_from_friends_list_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe "As a user" do
   it "I can see a friends profile from my friends list" do
-    user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy")
-    user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy")
+    user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy", username: '321')
+    user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy", username: '123')
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
 

--- a/spec/features/friends/user_can_visit_friends_profile_from_friends_list_spec.rb
+++ b/spec/features/friends/user_can_visit_friends_profile_from_friends_list_spec.rb
@@ -8,16 +8,15 @@ describe "As a user" do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
 
     visit profile_friends_path
-    fill_in :email_address, with: user_2.email
+    fill_in :username, with: user_2.username
     click_button "Add Friend"
 
-    expect(page).to have_link(user_2.email)
+    expect(page).to have_link(user_2.username, href: user_path(user_2.username))
 
-    click_link(user_2.email)
+    click_link(user_2.username)
 
     expect(page).to have_content(user_2.name)
-    expect(page).to have_content(user_2.email)
     expect(page).to have_content(user_2.bio)
-    expect(page).to have_link("#{user_2.name}'s Favorites")
+    expect(page).to have_link("#{user_2.username}'s Favorites")
   end
 end

--- a/spec/features/users/log_in_log_out_spec.rb
+++ b/spec/features/users/log_in_log_out_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe 'as a user I can log in' do
     OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
       :provider => 'google_oauth2',
       :info => { name: user.name,
-                 email: user.email
+                 email: user.email,
+                 username: user.username,
+                 image: user.image
                }
         })
 
@@ -38,7 +40,9 @@ RSpec.describe 'as a user I can log in' do
     OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
       :provider => 'google_oauth2',
       :info => { name: user.name,
-                 email: user.email
+                 email: user.email,
+                 username: user.username,
+                 image: user.image
                }
         })
 
@@ -61,7 +65,9 @@ RSpec.describe 'as a user I can log in' do
     OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
       :provider => 'google_oauth2',
       :info => { name: user.name,
-                 email: user.email
+                 email: user.email,
+                 username: user.username,
+                 image: user.image
                }
         })
 

--- a/spec/features/users/login_sad_path_spec.rb
+++ b/spec/features/users/login_sad_path_spec.rb
@@ -11,34 +11,6 @@ RSpec.describe 'as a user I can log in' do
 
     OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
       :provider => 'google_oauth2',
-      :info => { name: user.name,
-                 email: nil
-               }
-        })
-
-    visit root_path
-
-    click_link 'Log In With Google'
-
-    expect(page).to have_content("Email can't be blank")
-
-    expect(current_path).to eq(root_path)
-
-    expect(page).to have_link 'Log In With Google'
-
-    expect(User.count).to eq(0)
-  end
-
-  it 'I can connect to Google through OAuth' do
-
-    user = build(:user)
-
-    expect(User.count).to eq(0)
-
-    OmniAuth.config.test_mode = true
-
-    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
-      :provider => 'google_oauth2',
       :info => { name: nil,
                  email: user.email
                }

--- a/spec/features/users/user_edit_profile_spec.rb
+++ b/spec/features/users/user_edit_profile_spec.rb
@@ -7,10 +7,7 @@ describe 'as a user when I visit my profile' do
 
     visit profile_path
 
-    click_link "Edit Profile"
-      expect(current_path).to eq(profile_edit_path)
-
-    visit profile_path
+    expect(page).to have_link('Edit Profile', href: profile_edit_path)
   end
 
   it 'I can set my dietary preferences and they will stay checked when I revisit' do
@@ -22,6 +19,8 @@ describe 'as a user when I visit my profile' do
 
     expect(page).to have_content user.name
     expect(page).to have_content user.email
+    expect(page).to have_content user.bio
+    expect(page).to have_content user.username
 
     check 'vegetarian'
     check 'gluten_free'
@@ -29,7 +28,7 @@ describe 'as a user when I visit my profile' do
     click_button "Update Profile"
 
     expect(current_path).to eq profile_path
-    
+
     expect(page).to have_content("Profile Successfully Updated")
     expect(page).to have_content("vegetarian")
     expect(page).to have_content("gluten free")
@@ -43,23 +42,28 @@ describe 'as a user when I visit my profile' do
   end
 
   it 'can also update my bio/information' do
-      user = create(:user, bio: "It was all a dream, I used to read word up magazine")
-        old_bio = user.bio
+    user = create(:user, bio: "It was all a dream, I used to read word up magazine")
+    old_bio = user.bio
 
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-      visit profile_edit_path
+    visit profile_edit_path
 
-      fill_in 'bio', with: "I'm blowin' up like you thought I would, call the crib same number same hood it's all good"
+    expect(page).to have_content(user.username)
 
-      click_button "Update Profile"
+    fill_in 'bio', with: "I'm blowin' up like you thought I would, call the crib same number same hood it's all good"
+    fill_in 'username', with: 'newusername'
 
-      expect(current_path).to eq profile_path
+    click_button "Update Profile"
 
-      expect(page).to have_content("Profile Successfully Updated")
+    expect(current_path).to eq profile_path
 
-      expect(page).to_not have_content old_bio
-      expect(page).to have_content user.bio
+    expect(page).to have_content("Profile Successfully Updated")
+
+    expect(page).to_not have_content(old_bio)
+    expect(page).to have_content(user.bio)
+    expect(page).to have_content('newusername')
+    expect(page).to have_css("img[src*='https://i.kym-cdn.com/photos/images/newsfeed/001/076/734/879.jpg']")
   end
 
   it 'by default I do not have any dietary restrictions or bio' do
@@ -74,6 +78,5 @@ describe 'as a user when I visit my profile' do
     expect(page).to have_content user.email
     expect(page).to have_content "You haven't added any personal info yet, try adding some :^)"
     expect(page).to have_content "You have no dietary restrictions selected"
-
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe User, type: :model do
         user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy", username: '123')
         expect(user_1.friendships).to eq([])
         expect(user_2.friendships).to eq([])
-        user_1.add_friend(user_2.email)
+        user_1.add_friend(user_2.username)
         user_1.reload
         user_2.reload
         expect(user_1.friendships.length).to eq(1)
@@ -32,7 +32,7 @@ RSpec.describe User, type: :model do
       it "add_friend returns false when presented email address of current friend" do
         user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy", username: '321')
         user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy", username: '123')
-        user_1.add_friend(user_2.email)
+        user_1.add_friend(user_2.username)
         user_1.reload
         user_2.reload
         expect(user_1.add_friend(user_2.email)).to eq(false)
@@ -46,7 +46,7 @@ RSpec.describe User, type: :model do
       it "load_friends returns all friendships as user objects" do
         user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy", username: '321')
         user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy", username: '123')
-        user_1.add_friend(user_2.email)
+        user_1.add_friend(user_2.username)
         user_1.reload
         user_2.reload
         expect(user_1.load_friends).to eq([user_2])

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe User, type: :model do
   describe 'validations' do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:email) }
+    it { should validate_uniqueness_of(:username) }
+    it { should validate_presence_of(:image) }
   end
 
   describe 'relationships' do
@@ -16,8 +18,8 @@ RSpec.describe User, type: :model do
 
   describe 'class methods' do
       it "add_friend Creates a new friendship between users" do
-        user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy")
-        user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy")
+        user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy", username: '321')
+        user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy", username: '123')
         expect(user_1.friendships).to eq([])
         expect(user_2.friendships).to eq([])
         user_1.add_friend(user_2.email)
@@ -28,8 +30,8 @@ RSpec.describe User, type: :model do
       end
 
       it "add_friend returns false when presented email address of current friend" do
-        user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy")
-        user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy")
+        user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy", username: '321')
+        user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy", username: '123')
         user_1.add_friend(user_2.email)
         user_1.reload
         user_2.reload
@@ -42,8 +44,8 @@ RSpec.describe User, type: :model do
       end
 
       it "load_friends returns all friendships as user objects" do
-        user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy")
-        user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy")
+        user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy", username: '321')
+        user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy", username: '123')
         user_1.add_friend(user_2.email)
         user_1.reload
         user_2.reload


### PR DESCRIPTION
* User profiles no longer live at /users/:id -- they now live at /:username. Your profile still lives at /profile.
* User favorites no longer live at /users/:id/favorites -- they now live at /:username/favorites. Your favorites still live at /favorites.
* User friends no longer live at /users/:id/friends -- they now live at /:username/friends. Your friends still live at /friends.
* User profile displays username and photo
* Adds username and image column to users table - these are populated automatically when creating an account, but you can change your username in profile edit. The default username is the first part of your Gmail address before the @ sign. If you see a spongebob in the app, it's because that is the default in case Google does not provide one.
* Removed sad path on creating an account because it can't happen and it made testing hard (sorry mike)
* Add friends by searching by username instead of email
* Links to other users' pages (profile, favorites, friends) appear as their username instead of email address.