### PR TITLE
FR Omni Bugfix

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,12 +2,12 @@ class SessionsController < ApplicationController
   def create
     response = request.env['omniauth.auth']
     user = User.from_omniauth(response)
-    # if user.save
+    if user.save
       session[:user_id] = user.id
       flash['alert alert-success'] = "Logged in as #{user.name}"
-    # else
-    #   flash['alert alert-danger'] = user.errors.full_messages.to_sentence
-    # end
+    else
+      flash['alert alert-danger'] = user.errors.full_messages.to_sentence
+    end
     redirect_to root_path
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,12 +2,12 @@ class SessionsController < ApplicationController
   def create
     response = request.env['omniauth.auth']
     user = User.from_omniauth(response)
-    if user.save
+    # if user.save
       session[:user_id] = user.id
       flash['alert alert-success'] = "Logged in as #{user.name}"
-    else
-      flash['alert alert-danger'] = user.errors.full_messages.to_sentence
-    end
+    # else
+    #   flash['alert alert-danger'] = user.errors.full_messages.to_sentence
+    # end
     redirect_to root_path
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User < ApplicationRecord
   end
 
   def self.from_omniauth(response)
-    find_or_initialize_by(email: response['info']['email']) do |user|
+    find_or_create_by(email: response['info']['email']) do |user|
       user.name = response['info']['name']
       user.username = response['info']['email'].split('@').first if user.username.nil?
       user.image = response['info']['image']


### PR DESCRIPTION
Felt weird putting my initials on this since Fred did the work! This PR addresses an issue encountered when users would try to log into an existing account and the app would flash "email address is already taken". The fix was to use `find_or_create_by` instead of `find_or_initialize_by` in `User#self.from_omniauth` as the latter was not correctly returning existing user records.

100% coverage with 61 examples, zero Rubocop citations. This bugfix has already been pushed directly to Heroku to verify it works.
