### PR TITLE
AGL Edit Profile Image, Friending Fixes

### DIFF
--- a/app/controllers/profile/friends_controller.rb
+++ b/app/controllers/profile/friends_controller.rb
@@ -10,7 +10,7 @@ class Profile::FriendsController < ApplicationController
       current_user.reload
       flash['alert alert-success'] = 'Friend Added Successfully'
     else
-      flash['alert alert-danger'] = 'Invalid Email Entered, Try Again'
+      flash['alert alert-danger'] = 'Invalid entry, please try a different username'
     end
     redirect_to profile_friends_path
   end

--- a/app/controllers/profile/users_controller.rb
+++ b/app/controllers/profile/users_controller.rb
@@ -27,6 +27,6 @@ class Profile::UsersController < ApplicationController
   end
 
   def profile_params
-    params.permit(:bio, :username)
+    params.permit(:bio, :username, :image)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,9 +42,9 @@ class User < ApplicationRecord
 
   def self.from_omniauth(response)
     find_or_create_by(email: response['info']['email']) do |user|
-      user.name = response['info']['name']
-      user.username = response['info']['email'].split('@').first if user.username.nil?
-      user.image = response['info']['image']
+      user.name ||= response['info']['name']
+      user.username ||= response['info']['email'].split('@').first
+      user.image ||= response['info']['image']
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,11 +12,9 @@ class User < ApplicationRecord
 
   def add_friend(username)
     new_friend = User.find_by(username: username)
-    return false if new_friend.nil? || friends.include?(new_friend)
+    return unless friendable?(new_friend)
 
-    Friendship.create!(user_id: id, friend_id: new_friend.id)
-    Friendship.create!(user_id: new_friend.id, friend_id: id)
-    true
+    Friendship.create(user_id: id, friend_id: new_friend.id)
   end
 
   def share_recipe_with_friends(recipe_mailer_params)
@@ -42,9 +40,15 @@ class User < ApplicationRecord
 
   def self.from_omniauth(response)
     find_or_create_by(email: response['info']['email']) do |user|
-      user.name ||= response['info']['name']
-      user.username ||= response['info']['email'].split('@').first
-      user.image ||= response['info']['image']
+      user.name = response['info']['name']
+      user.username = response['info']['email'].split('@').first
+      user.image = response['info']['image']
     end
+  end
+
+  private
+
+  def friendable?(new_friend)
+    !(new_friend.nil? || friends.include?(new_friend) || new_friend == self)
   end
 end

--- a/app/views/profile/users/edit.html.erb
+++ b/app/views/profile/users/edit.html.erb
@@ -11,6 +11,8 @@
         <%= form_tag profile_path, method: :patch, :class => 'form-group' do %>
         <h3><%= label_tag "Username" %></h3><br>
         <%= text_area_tag :username, @user.username, :class => "form-control", :rows => 1 %>
+        <h3><%= label_tag "Image" %></h3><br>
+        <%= text_area_tag :image, @user.image, :class => "form-control", :rows => 2 %>
         <h3><%= label_tag "About Me" %></h3><br>
         <%= text_area_tag :bio, @user.bio, :class => "form-control", :rows => 5 %>
         <h3>Default Diet Preferences</h3>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     email  { Faker::Internet.email }
     bio  { Faker::Movies::Ghostbusters.quote }
     username  { Faker::DrivingLicence.uk_driving_licence }
+    image  { 'https://i.kym-cdn.com/photos/images/newsfeed/001/076/734/879.jpg' }
   end
 end

--- a/spec/features/friends/user_can_add_friends_spec.rb
+++ b/spec/features/friends/user_can_add_friends_spec.rb
@@ -36,7 +36,7 @@ describe "As a user" do
     click_button "Add Friend"
 
     expect(page).to_not have_content("Friend Added Successfully")
-    expect(page).to have_content("Invalid Email Entered, Try Again")
+    expect(page).to have_content("Invalid entry, please try a different username")
   end
 
   it "I cannot add a friend that is already on my friends list" do
@@ -55,6 +55,6 @@ describe "As a user" do
 
     fill_in :username, with: user_2.username
     click_button "Add Friend"
-    expect(page).to have_content("Invalid Email Entered, Try Again")
+    expect(page).to have_content("Invalid entry, please try a different username")
   end
 end

--- a/spec/features/friends/user_can_add_friends_spec.rb
+++ b/spec/features/friends/user_can_add_friends_spec.rb
@@ -39,6 +39,19 @@ describe "As a user" do
     expect(page).to have_content("Invalid entry, please try a different username")
   end
 
+  it "I cannot add myself as a friend" do
+    user = create(:user, username: 'user')
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit profile_friends_path
+    fill_in :username, with: "user"
+    click_button "Add Friend"
+
+    expect(page).to_not have_content("Friend Added Successfully")
+    expect(page).to have_content("Invalid entry, please try a different username")
+  end
+
   it "I cannot add a friend that is already on my friends list" do
     user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy", username: '321')
     user_2 = User.create!(name: "G", email: "G@example.com", bio: "Also a Fun Guy", username: '123')

--- a/spec/features/users/user_edit_profile_spec.rb
+++ b/spec/features/users/user_edit_profile_spec.rb
@@ -53,6 +53,7 @@ describe 'as a user when I visit my profile' do
 
     fill_in 'bio', with: "I'm blowin' up like you thought I would, call the crib same number same hood it's all good"
     fill_in 'username', with: 'newusername'
+    fill_in 'image', with: 'https://www.sbmania.net/pictures/40b/194.png'
 
     click_button "Update Profile"
 
@@ -63,7 +64,7 @@ describe 'as a user when I visit my profile' do
     expect(page).to_not have_content(old_bio)
     expect(page).to have_content(user.bio)
     expect(page).to have_content('newusername')
-    expect(page).to have_css("img[src*='https://i.kym-cdn.com/photos/images/newsfeed/001/076/734/879.jpg']")
+    expect(page).to have_css("img[src*='https://www.sbmania.net/pictures/40b/194.png']")
   end
 
   it 'by default I do not have any dietary restrictions or bio' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe User, type: :model do
       user_1.reload
       user_2.reload
       expect(user_1.friendships.length).to eq(1)
-      expect(user_2.friendships.length).to eq(1)
+      expect(user_2.friendships.length).to eq(0)
     end
 
     it "add_friend returns false when presented email address of current friend" do
@@ -35,12 +35,12 @@ RSpec.describe User, type: :model do
       user_1.add_friend(user_2.username)
       user_1.reload
       user_2.reload
-      expect(user_1.add_friend(user_2.email)).to eq(false)
+      expect(user_1.add_friend(user_2.email)).to eq(nil)
     end
 
     it "add_friend returns false when given invalid email address" do
       user_1 = User.create!(name: "F", email: "F@example.com", bio: "Fun Guy")
-      expect(user_1.add_friend("asdf")).to eq(false)
+      expect(user_1.add_friend("asdf")).to eq(nil)
     end
 
     it 'can initalize a new user from google Omniauth' do


### PR DESCRIPTION
* Change error message when user isn't found for friending
* Friendship is now one-way (Twitter model). Adding someone as a friend doesn't make them add you as a friend anymore (non-reciprocal).
* Cannot friend self anymore
* New helper method to determine if a user is friendable
* Can edit profile picture now
* Update friend feature specs

No rubocop citations, 99.49% coverage
